### PR TITLE
Resolves #9 Added tooltips to column headers with description and point value

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -45,6 +45,9 @@ class ChangeHistory extends React.Component {
 
 class ColumnHeaders extends React.Component {
   render() {
+    
+    let tooltipText = '';
+    
     return (
         <TableHead className="headerStyle">
         <TableRow>
@@ -144,7 +147,6 @@ class App extends Component {
   }
 
   render() {
-    let tooltipText = ''
 
     return (
       <div className="App">

--- a/src/App.js
+++ b/src/App.js
@@ -36,6 +36,7 @@ class App extends Component {
   }
 
   render() {
+    let tooltipText = ''
 
     return (
       <div className="App">
@@ -53,8 +54,8 @@ class App extends Component {
                     this.state.stats.map((row, playerIndex) => {
                       if (row.name === 'ZOMBIES') {
                          return (<TextField
-                           type='number'
-                           key={playerIndex}
+                          type='number'
+                          key={playerIndex}
                           value={row['zombiewins']}
                           style={{width: 40}}
                           onChange={(e) => this.onCellChange(playerIndex, 'zombiewins', row, e.target.value)}                                                 
@@ -78,10 +79,19 @@ class App extends Component {
             <TableHead className="headerStyle">
                 <TableRow>
                     {Object.values(helpers.columns).map((header, headerIndex) => {
-                      if (header !== 'Season' && header !== 'Zombie Wins') {
-                          return (
-                            <TableCell key={headerIndex}>{header}</TableCell>
-                          );
+                      if (header.header !== 'Season' && header.header !== 'Zombie Wins') {
+                        tooltipText = header.header === 'Name' ? 
+                          tooltipText = header.tooltip :
+                          tooltipText = header.tooltip + '<br />Value:  ' + header.value
+                        return (
+                          <TableCell 
+                            key={headerIndex}
+                            data-multiline={true}
+                            data-tip={tooltipText}
+                          >{header.header}
+                            <ReactTooltip />
+                          </TableCell>
+                        );
                       }
                       return null;
                     })}

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -31,22 +31,86 @@ var helpers = {
     },
 
     columns: {
-        name: 'Name',
-        season: 'Season',
-        zombiewins: 'Zombie Wins',
-        human: 'Human Win',
-        survivor: 'Survivor',
-        coweringdefeat: 'Cowering Defeat',
-        resdhuman: 'Res\'d Human',
-        lostbulls: 'Lost Bullseyes',
-        catches: 'Catches',
-        firstrdkill: 'First Round Kill',
-        firstrdelim: 'First Round Elimination',
-        resdkill: 'Res\'d Kill',
-        doubletap: 'Double Tap',
-        doublechomp: 'Double Chomp',
-        zombiehero: 'Zombie Hero',
-        buffet: 'Buffet'
+        name: {
+            header: 'Name',
+            tooltip: 'Player Name',
+            value: ''
+        },
+        season: {
+            header: 'Season',
+            tooltip: '',
+            value: ''
+        },
+        zombiewins: {
+            header: 'Zombie Wins',
+            tooltip: '',
+            value: ''
+        },
+        human: {
+            header: 'Human Win',
+            tooltip: 'Kill all zombies as a human',
+            value: 1
+        },
+        survivor: {
+            header: 'Survivor',
+            tooltip: 'Only one human left with at least 3 zombies.<br />Must call after turn and zombies must target survivor (no res).<br />If zombies cannot kill human by its next turn, human becomes survivor',
+            value: 1
+        },
+        coweringdefeat: {
+            header: 'Cowering Defeat',
+            tooltip: 'Human calls survivor but is killed by zombies',
+            value: -1
+        },
+        resdhuman: {
+            header: 'Res\'d Human',
+            tooltip: 'Human resurrects and eliminates all zombies',
+            value: 1
+        },
+        lostbulls: {
+            header: 'Lost Bullseyes',
+            tooltip: 'Thrower did not declare target of the bullseye',
+            value: -1
+        },
+        catches: {
+            header: 'Catches',
+            tooltip: 'Catch a dart that bounces out of the board',
+            value: 1
+        },
+        firstrdkill: {
+            header: 'First Round Kill',
+            tooltip: 'In the throwers first turn, they kill another player',
+            value: 1
+        },
+        firstrdelim: {
+            header: 'First Round Elimination',
+            tooltip: 'In the throwers first turn, they kill another player and hit bullseye to eliminate them',
+            value: 2
+        },
+        resdkill: {
+            header: 'Res\'d Kill',
+            tooltip: 'Ressurect and kill a human in one turn',
+            value: 2
+        },
+        doubletap: {
+            header: 'Double Tap',
+            tooltip: 'Kill the same human twice as a human',
+            value: 1
+        },
+        doublechomp: {
+            header: 'Double Chomp',
+            tooltip: 'Kill the same human twice as a zombie',
+            value: 1
+        },
+        zombiehero: {
+            header: 'Zombie Hero',
+            tooltip: 'Last zombie to throw in a survivor situation kills the human',
+            value: 2
+        },
+        buffet: {
+            header: 'Buffet',
+            tooltip: 'I have no clue what this one is',
+            value: 2
+        }
     },
 
     statValues: {


### PR DESCRIPTION
Added tooltips. In helpers, moved value and tooltip into columns object. I think we should be able to clean that up a little bit more and use values from that in the calculation functions in helpers, but that seemed out of scope for this work. Will add a new issue for it.

Also, please review the tooltip text. I didn't know what Buffet was.