### PR TITLE
Cleaned up player stats table and added row highlighting on hover

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -29,9 +29,7 @@
 
 tr:nth-child(even) {background-color: #f2f2f2;}
 
-input {
-  width: 60px;
-}
+#StatsTable tr:hover { background: #95b3e2; }
 
 .collapseBorder {
   border-collapse: collapse;
@@ -41,18 +39,14 @@ input {
   background-color: gold;
 }
 
-input.MuiInput-input-15 {
-  width: auto;
-}
-
 .headerStyle {
-  padding: 4px 6px 4px 6px;
-  width: auto;
+  /* padding: 4px 6px 4px 6px; */
+  /* width: auto; */
   font-size: 1rem;
   font-weight: 600;
 }
 
 .cellStyle {
-  padding: 4px 6px 4px 6px;
+  /* padding: 4px 6px 4px 6px; */
   width: 5%;
 }

--- a/src/components/ColumnHeaders.js
+++ b/src/components/ColumnHeaders.js
@@ -1,12 +1,11 @@
 import React from 'react';
-import { TableCell, TableHead, TableRow } from 'material-ui/Table';
 import ReactTooltip from 'react-tooltip';
-import TrackedStats from '../lib/TrackedStats.js';
+import TrackedStats from '../lib/TrackedStats.js'
 
 export default () => (
-    <TableHead className="headerStyle">
-      <TableRow>
-        <TableCell>Player Name</TableCell>
+    <thead className="headerStyle">
+      <tr>
+        <th>Player Name</th>
         {
           Object.values(TrackedStats).map((stat, statIndex) => {
             return (
@@ -14,19 +13,20 @@ export default () => (
             );
           })
         }
-      </TableRow>
-    </TableHead>
+      </tr>
+    </thead>
 )
 
 const ColumnHeader = ({index, stat}) => {
   return (
-    <TableCell 
+    <th 
+      class="mdl-data-table__cell--non-numeric"
       key={index} 
       data-multiline={true} 
       data-tip={stat.tooltip + '<br />Value:  ' + stat.value}>
           {stat.header}
           <ReactTooltip />
-    </TableCell>
+    </th>
 
 )}
 

--- a/src/components/ColumnHeaders.js
+++ b/src/components/ColumnHeaders.js
@@ -20,7 +20,7 @@ export default () => (
 const ColumnHeader = ({index, stat}) => {
   return (
     <th 
-      class="mdl-data-table__cell--non-numeric"
+      className="mdl-data-table__cell--non-numeric"
       key={index} 
       data-multiline={true} 
       data-tip={stat.tooltip + '<br />Value:  ' + stat.value}>

--- a/src/components/PlayerRow.js
+++ b/src/components/PlayerRow.js
@@ -1,40 +1,37 @@
 import React from 'react';
 import '../App.css';
 import TextField from 'material-ui/TextField';
-import { TableCell, TableRow } from 'material-ui/Table';
 import ReactTooltip from 'react-tooltip';
 import TrackedStats from '../lib/TrackedStats.js';
 
 export default ({playerIndex, isDaKing, kingPoints, row, onCellChange}) => { 
   let outOfFirst = (kingPoints - row['totalPoints']) * -1;
   return (
-        <TableRow key={playerIndex}>
-          <TableCell className="cellStyle">
-            <TextField 
+        <tr key={playerIndex}>
+          <td>
+            <TextField
               type='text'
               value={row.name}
               disabled
-              style={{width: 75}}
               className={isDaKing === true ? 'king' : undefined}
               data-tip={outOfFirst}
             />
             <ReactTooltip />
-          </TableCell>
+          </td>
         {
           Object.keys(TrackedStats).map((columnName, index) => {
             return (
-              <TableCell key={index} className="cellStyle">
+              <td key={index}>
                 <TextField
                   type='number'
                   value={row[columnName]}
-                  style={{width: 40}}
                   onChange={(e) => onCellChange(columnName, row, e.target.value)}
                 />
-              </TableCell>
+              </td>
             );
           })
         }
-        </TableRow>
+        </tr>
 
   )
 }

--- a/src/components/PlayerStats.js
+++ b/src/components/PlayerStats.js
@@ -1,12 +1,13 @@
 import React from 'react';
 import PlayerRow from './PlayerRow.js';
-import Table, { TableBody } from 'material-ui/Table';
+import Card from 'material-ui/Card';
 import ColumnHeaders from './ColumnHeaders';
 
 export default ({stats, kingPoints, isDaKing, onCellChange}) =>  ( 
-    <Table>
+  <Card>
+    <table id="StatsTable">
         <ColumnHeaders />
-        <TableBody>
+        <tbody>
             {
               stats.sort(function(a, b) { return b.totalPoints - a.totalPoints; })
                 .map((row, playerIndex) => {
@@ -25,6 +26,7 @@ export default ({stats, kingPoints, isDaKing, onCellChange}) =>  (
                 return null;
               })
             }
-        </TableBody>
-    </Table>
+        </tbody>
+    </table>
+  </Card>
 )


### PR DESCRIPTION
Removed Material UI table elements for player stats table and went back to standard html. Wrapped that table in a material Card and left the InputField as material and it kept the table looking decently material-y while actually listening to css. Added in row highlighting for player stats table. Resolves #5 and resolves #27.